### PR TITLE
Added JSON commands to list of default commands.

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -16,6 +16,14 @@
         "command": "safe_html_deentitize"
     },
     {
+        "caption": "StringEncode: JSON Escape",
+        "command": "json_escape"
+    },
+    {
+        "caption": "StringEncode: JSON Unescape",
+        "command": "json_unescape"
+    },
+    {
         "caption": "StringEncode: URL Encode",
         "command": "url_encode"
     },


### PR DESCRIPTION
I was trying to get the JSON commands to work and finally realized that they hadn't been included in the list of default commands that shows up when you hit shift+super+p.

This will add the JSON commands.

Thanks for this package, it's great!
