### PR TITLE
Removed `cmp_to_key` for Sublime Text 2 support

### DIFF
--- a/string_encode.py
+++ b/string_encode.py
@@ -3,7 +3,6 @@ import urllib
 import base64
 import re
 import json
-from functools import cmp_to_key
 
 import sublime_plugin
 


### PR DESCRIPTION
Sublime Text 2 was not able to load the StringEncode plugin when installed via Package Control. The error message I got was:

```
Reloading plugin /home/todd/.config/sublime-text-2/Packages/StringEncode/string_encode.py
Traceback (most recent call last):
  File "./sublime_plugin.py", line 62, in reload_plugin
  File "./string_encode.py", line 6, in <module>
    from functools import cmp_to_key
ImportError: cannot import name cmp_to_key
```

After removing the line in question, the plugin went back to functioning. I didn't see any other locations in the code which used `cmp_to_key`

For reference, I am on Linux Mint 14 and running Sublime Text 2.0.2, Build 2221. I have not yet upgraded as not all of my plugins are compatible.

http://www.caniswitchtosublimetext3.com/14f
