### PR TITLE
Pad base64 strings before decoding

### DIFF
--- a/string_encode.py
+++ b/string_encode.py
@@ -270,7 +270,7 @@ class Base64EncodeCommand(StringEncode):
 class Base64DecodeCommand(StringEncode):
 
     def encode(self, text):
-        return base64.b64decode(text).decode('raw_unicode_escape')
+        return base64.b64decode(text + '===').decode('raw_unicode_escape')
 
 
 class Md5EncodeCommand(StringEncode):


### PR DESCRIPTION
Base64 decoder gracefully handles extraneous padding, therefore this should enable decoding unpadded strings

Resolves #37 