### PR TITLE
allow users to decode unicode escaped texts

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -92,6 +92,10 @@
         "command": "unicode_hex"
     },
     {
+        "caption": "StringEncode: Decode Escaped Unicode",
+        "command": "unicode_escape"
+    },
+    {
         "caption": "StringEncode: Hexadecimal to Unicode",
         "command": "hex_unicode"
     }

--- a/Example.sublime-keymap
+++ b/Example.sublime-keymap
@@ -11,5 +11,6 @@
     // { "keys": ["super+shift+5"], "command": "url_encode", "args": {"old_school": true} },
     { "keys": ["super+ctrl+5"], "command": "url_decode" },
     { "keys": ["ctrl+shift+r"], "command": "escape_regex" },
+    { "keys": ["ctrl+shift+u"], "command": "unicode_escape" },
     { "keys": ["super+ctrl+3"], "command": "hex_dec" }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -17,6 +17,10 @@
                         "caption": "-"
                     },
                     {
+                        "caption": "Decode Escaped Unicode",
+                        "command": "unicode_escape"
+                    },
+                    {
                         "caption": "HTML Entitize",
                         "command": "html_entitize"
                     },

--- a/string_encode.py
+++ b/string_encode.py
@@ -6,6 +6,7 @@ import hashlib
 import sys
 import sublime
 import sublime_plugin
+import codecs
 
 from .stringencode.escape_table import (
     html_escape_table,
@@ -30,6 +31,7 @@ class StringEncodePaste(sublime_plugin.WindowCommand):
         items = [
             ('Html Entitize', 'html_entitize'),
             ('Html Deentitize', 'html_deentitize'),
+            ('Unicode Escape', 'unicode_escape'),
             ('Css Escape', 'css_escape'),
             ('Css Unescape', 'css_unescape'),
             ('Safe Html Entitize', 'safe_html_entitize'),
@@ -91,6 +93,12 @@ class StringEncode(sublime_plugin.TextCommand):
             text = self.view.substr(region)
             replacement = self.encode(text, **kwargs)
             self.view.replace(edit, region, replacement)
+
+
+class UnicodeEscapeCommand(StringEncode):
+
+    def encode(self, text):
+        return codecs.decode(text, 'unicode-escape')
 
 
 class HtmlEntitizeCommand(StringEncode):


### PR DESCRIPTION
Decoding strings like \\uXXXX to normal Unicode text.
See this question:
[SO questopm](https://stackoverflow.com/questions/2828284/conversion-of-strings-like-uxxxx-in-python)