### PR TITLE
Fixes for SHA encoding commands

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -52,15 +52,15 @@
         "command": "url_decode"
     },
     {
-        "caption": "MD5",
+        "caption": "StringEncode: MD5 Encode",
         "command": "md5_encode"
     },
     {
-        "caption": "Sha256",
+        "caption": "StringEncode: Sha256 Encode",
         "command": "sha256_encode"
     },
     {
-        "caption": "Sha512",
+        "caption": "StringEncode: Sha512 Encode",
         "command": "sha512_encode"
     },
     {

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -56,8 +56,16 @@
         "command": "md5_encode"
     },
     {
+        "caption": "StringEncode: Sha1 Encode",
+        "command": "sha1_encode"
+    },
+    {
         "caption": "StringEncode: Sha256 Encode",
         "command": "sha256_encode"
+    },
+    {
+        "caption": "StringEncode: Sha384 Encode",
+        "command": "sha384_encode"
     },
     {
         "caption": "StringEncode: Sha512 Encode",

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -76,8 +76,16 @@
                         "command": "md5_encode"
                     },
                     {
+                        "caption": "Sha1 Encode",
+                        "command": "sha1_encode"
+                    },
+                    {
                         "caption": "Sha256 Encode",
                         "command": "sha256_encode"
+                    },
+                    {
+                        "caption": "Sha384 Encode",
+                        "command": "sha384_encode"
                     },
                     {
                         "caption": "Sha512 Encode",

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -72,15 +72,15 @@
                         "command": "base64_decode"
                     },
                     {
-                        "caption": "MD5",
+                        "caption": "MD5 Encode",
                         "command": "md5_encode"
                     },
                     {
-                        "caption": "Sha256",
+                        "caption": "Sha256 Encode",
                         "command": "sha256_encode"
                     },
                     {
-                        "caption": "Sha512",
+                        "caption": "Sha512 Encode",
                         "command": "sha512_encode"
                     },
                     {

--- a/string_encode.py
+++ b/string_encode.py
@@ -46,7 +46,9 @@ class StringEncodePaste(sublime_plugin.WindowCommand):
             ('Base64 Encode', 'base64_encode'),
             ('Base64 Decode', 'base64_decode'),
             ('Md5 Encode', 'md5_encode'),
+            ('Sha1 Encode', 'sha1_encode'),
             ('Sha256 Encode', 'sha256_encode'),
+            ('Sha384 Encode', 'sha384_encode'),
             ('Sha512 Encode', 'sha512_encode'),
             ('Escape Regex', 'escape_regex'),
             ('Escape Like', 'escape_like'),
@@ -287,10 +289,22 @@ class Md5EncodeCommand(StringEncode):
         return hashlib.md5(bytes(text, 'utf-8')).hexdigest()
 
 
+class Sha1EncodeCommand(StringEncode):
+
+    def encode(self, text):
+        return hashlib.sha1(bytes(text, 'utf-8')).hexdigest()
+
+
 class Sha256EncodeCommand(StringEncode):
 
     def encode(self, text):
         return hashlib.sha256(bytes(text, 'utf-8')).hexdigest()
+
+
+class Sha384EncodeCommand(StringEncode):
+
+    def encode(self, text):
+        return hashlib.sha384(bytes(text, 'utf-8')).hexdigest()
 
 
 class Sha512EncodeCommand(StringEncode):

--- a/string_encode.py
+++ b/string_encode.py
@@ -284,25 +284,19 @@ class Base64DecodeCommand(StringEncode):
 class Md5EncodeCommand(StringEncode):
 
     def encode(self, text):
-        hasher = hashlib.md5()
-        hasher.update(bytes(text, 'utf-8'))
-        return hasher.hexdigest()
+        return hashlib.md5(bytes(text, 'utf-8')).hexdigest()
 
 
 class Sha256EncodeCommand(StringEncode):
 
     def encode(self, text):
-        hasher = hashlib.sha256()
-        hasher.update(bytes(text, 'utf-8'))
-        return hasher.hexdigest()
+        return hashlib.sha256(bytes(text, 'utf-8')).hexdigest()
 
 
 class Sha512EncodeCommand(StringEncode):
 
     def encode(self, text):
-        hasher = hashlib.sha512()
-        hasher.update(bytes(text, 'utf-8'))
-        return hasher.hexdigest()
+        return hashlib.sha512(bytes(text, 'utf-8')).hexdigest()
 
 
 class Escaper(StringEncode):


### PR DESCRIPTION
1. fix labels in menu and command palette.
2. slightly more compact implementation to save some lines of code.

Note: New commands need to be added to `__all__`, once #45 is merged.