### PR TITLE
Add Base16 and Base32 encode/decode commands

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -72,6 +72,22 @@
         "command": "sha512_encode"
     },
     {
+        "caption": "StringEncode: Base16 Encode",
+        "command": "base16_encode"
+    },
+    {
+        "caption": "StringEncode: Base16 Decode",
+        "command": "base16_decode"
+    },
+    {
+        "caption": "StringEncode: Base32 Encode",
+        "command": "base32_encode"
+    },
+    {
+        "caption": "StringEncode: Base32 Decode",
+        "command": "base32_decode"
+    },
+    {
         "caption": "StringEncode: Base64 Encode",
         "command": "base64_encode"
     },

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -64,6 +64,22 @@
                         "command": "url_decode"
                     },
                     {
+                        "caption": "Base16 Encode",
+                        "command": "base16_encode"
+                    },
+                    {
+                        "caption": "Base16 Decode",
+                        "command": "base16_decode"
+                    },
+                    {
+                        "caption": "Base32 Encode",
+                        "command": "base32_encode"
+                    },
+                    {
+                        "caption": "Base32 Decode",
+                        "command": "base32_decode"
+                    },
+                    {
                         "caption": "Base64 Encode",
                         "command": "base64_encode"
                     },

--- a/string_encode.py
+++ b/string_encode.py
@@ -37,6 +37,10 @@ __all__ = [
     "JsonUnescapeCommand",
     "UrlEncodeCommand",
     "UrlDecodeCommand",
+    "Base16EncodeCommand",
+    "Base16DecodeCommand",
+    "Base32EncodeCommand",
+    "Base32DecodeCommand",
     "Base64EncodeCommand",
     "Base64DecodeCommand",
     "Md5EncodeCommand",
@@ -69,6 +73,10 @@ class StringEncodePaste(sublime_plugin.WindowCommand):
             ('Json Unescape', 'json_unescape'),
             ('Url Encode', 'url_encode'),
             ('Url Decode', 'url_decode'),
+            ('Base16 Encode', 'base16_encode'),
+            ('Base16 Decode', 'base16_decode'),
+            ('Base32 Encode', 'base32_encode'),
+            ('Base32 Decode', 'base32_decode'),
             ('Base64 Encode', 'base64_encode'),
             ('Base64 Decode', 'base64_decode'),
             ('Md5 Encode', 'md5_encode'),
@@ -298,6 +306,30 @@ class UrlDecodeCommand(StringEncode):
 
     def encode(self, text):
         return unquote_plus(text)
+
+
+class Base16EncodeCommand(StringEncode):
+
+    def encode(self, text):
+        return str(base64.b16encode(bytes(text, 'utf-8')), 'ascii')
+
+
+class Base16DecodeCommand(StringEncode):
+
+    def encode(self, text):
+        return str(base64.b16decode(text), 'utf-8')
+
+
+class Base32EncodeCommand(StringEncode):
+
+    def encode(self, text):
+        return str(base64.b32encode(bytes(text, 'utf-8')), 'ascii')
+
+
+class Base32DecodeCommand(StringEncode):
+
+    def encode(self, text):
+        return str(base64.b32decode(text), 'utf-8')
 
 
 class Base64EncodeCommand(StringEncode):


### PR DESCRIPTION
This PR adds Base16 and Base32 convertion commands.

Goal is to promote this package in favor of re-adding old [Base Encoder in PR 9001](https://github.com/wbond/package_control_channel/pull/9001) to packagecontrol.io

Note: Commands need to be added to `__all__`, once #45 is merged.